### PR TITLE
Added support for Udp devices, refactoring.

### DIFF
--- a/src/NmeaParser.WinDesktop/NmeaParser.WinDesktop.csproj
+++ b/src/NmeaParser.WinDesktop/NmeaParser.WinDesktop.csproj
@@ -38,6 +38,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GlobalSuppressions.cs">
@@ -45,6 +46,7 @@
     </Compile>
     <Compile Include="SerialPortDevice.cs" />
     <Compile Include="Properties\AssemblyInfo.Desktop.cs" />
+    <Compile Include="UdpDevice.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/src/NmeaParser.WinDesktop/UdpDevice.cs
+++ b/src/NmeaParser.WinDesktop/UdpDevice.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NmeaParser
+{
+    /// <summary>
+    /// Udp NMEA device
+    /// </summary>
+    public class UdpDevice : NmeaDevice
+    {
+        private UdpClient _client;
+        private UdpState _state;
+        private IPEndPoint _endPoint;
+        private bool _listen;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="ip">ip address string</param>
+        /// <param name="port">port number</param>
+        public UdpDevice(string ip, int port)
+            : this(new IPEndPoint(IPAddress.Parse(ip), port))
+        {}
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="ipAddress">ip address</param>
+        /// <param name="port">port number</param>
+        public UdpDevice(IPAddress ipAddress, int port)
+            :this(new IPEndPoint(ipAddress, port))
+        {}
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="ipEndPoint">ip endpoint</param>
+        public UdpDevice(IPEndPoint ipEndPoint)
+        {
+            _endPoint = ipEndPoint;
+
+            _client = new UdpClient(_endPoint);
+            _state = new UdpState() { EndPoint = _endPoint, UdpClient = _client };
+        }
+
+        /// <summary>
+        /// Specify desired endpoint if datagrams are received from multiple sources
+        /// </summary>
+        public IPEndPoint ExpectedEndpoint { get; set; }
+
+        /// <summary>
+        /// Override. Set closeTask result as true since we are not using base's parser
+        /// </summary>
+        protected override void StartParser()
+        {
+            closeTask = new TaskCompletionSource<bool>();
+            closeTask.SetResult(true);
+        }
+
+        /// <summary>
+        /// Override. Start listening and attach async callback.
+        /// </summary>
+        /// <returns>completed task resolved as null stream</returns>
+        protected override Task<Stream> OpenStreamAsync()
+        {
+            _listen = true;
+            _client.BeginReceive(Callback, _state);
+            return Task.FromResult<Stream>(null);
+        }
+
+        /// <summary>
+        /// Override. Stop listening.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <returns>completed task resolved to true</returns>
+        protected override Task CloseStreamAsync(System.IO.Stream stream)
+        {
+            _listen = false;
+            return Task.FromResult(true);
+        }
+
+        /// <summary>
+        /// "Dispose" udp client.
+        /// </summary>
+        protected override void Dispose(bool force)
+        {
+            _client = null;
+        }
+
+        /// <summary>
+        /// Handle received datagrams async
+        /// </summary>
+        /// <param name="ar"></param>
+        private void Callback(IAsyncResult ar)
+        {
+            var client = (UdpClient)((UdpState)ar.AsyncState).UdpClient;
+            var endPoint = new IPEndPoint(IPAddress.Any, 0);
+            byte[] bytes = client.EndReceive(ar, ref endPoint);
+            
+            if (!_listen)
+                return;
+
+            if (ExpectedEndpoint == null || (ExpectedEndpoint.Address.Equals(endPoint.Address) && ExpectedEndpoint.Port.Equals(endPoint.Port)))
+                OnData(bytes); // parse
+            client.BeginReceive(Callback, ar.AsyncState);
+        }
+    }
+
+    /// <summary>
+    /// Udp helper class.
+    /// http://msdn.microsoft.com/en-us/library/c8s04db1(v=VS.80).aspx
+    /// </summary>
+    public class UdpState
+    {
+        /// <summary>
+        /// IPEndPoint
+        /// </summary>
+        public IPEndPoint EndPoint;
+
+        /// <summary>
+        /// UdpClient
+        /// </summary>
+        public UdpClient UdpClient;
+    }
+}

--- a/src/SampleApp.WinDesktop/MainWindow.xaml
+++ b/src/SampleApp.WinDesktop/MainWindow.xaml
@@ -2,63 +2,64 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 		xmlns:local="clr-namespace:SampleApp.WinDesktop"
-        Title="Sample App" Height="500" Width="625">
-	<Grid>
-		<Grid.Resources>
-			<Style TargetType="UserControl" x:Key="card">
-				<Setter Property="Margin" Value="10" />
-				<Setter Property="Padding" Value="10" />
-				<Setter Property="Background" Value="White" />
-				<Setter Property="Effect">
-					<Setter.Value>
-						<DropShadowEffect Direction="0"  ShadowDepth="0"
+        Title="Sample App" Height="500" Width="610.232">
+    <Grid>
+        <Grid.Resources>
+            <Style TargetType="UserControl" x:Key="card">
+                <Setter Property="Margin" Value="10" />
+                <Setter Property="Padding" Value="10" />
+                <Setter Property="Background" Value="White" />
+                <Setter Property="Effect">
+                    <Setter.Value>
+                        <DropShadowEffect Direction="0"  ShadowDepth="0"
 										  BlurRadius="20" Opacity=".5" />
-					</Setter.Value>
-				</Setter>
-			</Style>
-		</Grid.Resources>
-		<TabControl>
-			<TabItem Header="GPS Info">
-				<ScrollViewer HorizontalScrollBarVisibility="Disabled" Background="#FFEEEEEE">
-					<WrapPanel>
-						<local:GprmcControl x:Name="gprmcView" Style="{StaticResource card}" />
-						<local:GpggaControl x:Name="gpggaView" Style="{StaticResource card}" />
-						<local:GpgsaControl x:Name="gpgsaView" Style="{StaticResource card}" />
-						<local:GpgllControl x:Name="gpgllView" Style="{StaticResource card}" />
-						<local:PgrmeControl x:Name="pgrmeView" Style="{StaticResource card}" />
-					</WrapPanel>
-				</ScrollViewer>
-			</TabItem>
-			<TabItem Header="GPS Satellite view">
-				<Grid>
-					<Grid.RowDefinitions>
-						<RowDefinition />
-						<RowDefinition Height="100" />
-					</Grid.RowDefinitions>
-				<local:SatelliteView MaxWidth="{Binding ActualHeight, ElementName=satView}"
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </Grid.Resources>
+        <TabControl>
+            <TabItem Header="GPS Info">
+                <ScrollViewer HorizontalScrollBarVisibility="Disabled" Background="#FFEEEEEE">
+                    <WrapPanel>
+                        <local:GprmcControl x:Name="gprmcView" Style="{StaticResource card}" />
+                        <local:GpggaControl x:Name="gpggaView" Style="{StaticResource card}" />
+                        <local:GpgsaControl x:Name="gpgsaView" Style="{StaticResource card}" />
+                        <local:GpgllControl x:Name="gpgllView" Style="{StaticResource card}" />
+                        <local:PgrmeControl x:Name="pgrmeView" Style="{StaticResource card}" />
+                    </WrapPanel>
+                </ScrollViewer>
+            </TabItem>
+            <TabItem Header="GPS Satellite view">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition Height="100" />
+                    </Grid.RowDefinitions>
+                    <local:SatelliteView MaxWidth="{Binding ActualHeight, ElementName=satView}"
 					Grid.Column="1" x:Name="satView" />
-					<local:SatelliteSnr Grid.Row="1"
+                    <local:SatelliteSnr Grid.Row="1"
 						GpgsvMessages="{Binding GpgsvMessages, ElementName=satView}" />
-				</Grid>
-			</TabItem>
-			<TabItem Header="Messages">
-				<TextBox x:Name="output"
+                </Grid>
+            </TabItem>
+            <TabItem Header="Messages">
+                <TextBox x:Name="output"
 				 AcceptsReturn="True"
 				 IsReadOnly="True"
 				 VerticalScrollBarVisibility="Auto"
 				 HorizontalScrollBarVisibility="Visible"
 				 />
-			</TabItem>
-		</TabControl>
-		
-		<Grid.ColumnDefinitions>
-			<ColumnDefinition Width="*"/>
-			<ColumnDefinition Width="Auto"/>
-		</Grid.ColumnDefinitions>
-		
-		
-		
-	
-		
-	</Grid>
+            </TabItem>
+        </TabControl>
+        <Button Content="{Binding UIButtonContent}" Click="UIButton_Click" HorizontalAlignment="Right" VerticalAlignment="Top" Width="105" Margin="0,1,2,0"/>
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+
+
+
+
+    </Grid>
 </Window>


### PR DESCRIPTION
Added Udp device support.

Added start/stop device button to UI (& related logic) to SampleApp.WinDesktop.

Changed NmeaDevice closeTask field as protected.
Changed NmeaDevice OnData() method as protected.
Changed NmeaDevice StartParser() method as protected virtual, refactored read task.

Stopping any device sometimes hanged the parser (waiting closeTask forever). 

Signature changes allowed implementation of UdpDevice w/o breaking any existing functionality.