### PR TITLE
Added option to extend the recognized NmeaMessages from outside the Assembly

### DIFF
--- a/src/NmeaParser.Shared/Nmea/NmeaMessage.cs
+++ b/src/NmeaParser.Shared/Nmea/NmeaMessage.cs
@@ -109,11 +109,21 @@ namespace NmeaParser.Nmea
 		{
 			messageTypes = new Dictionary<string, ConstructorInfo>();
 			var typeinfo = typeof(NmeaMessage).GetTypeInfo();
-			foreach (var subclass in typeinfo.Assembly.DefinedTypes.Where(t => t.IsSubclassOf(typeof(NmeaMessage))))
-			{
-			    RegisterNmeaMessage(subclass);
-			}
+			RegisterNmeaMessages(typeinfo.Assembly);
 		}
+
+        /// <summary>
+        /// Finds all defined types in the provided assembly that declare the NmeaMessageTypeAttribute and registers
+        /// them as a parse 'target'.
+        /// </summary>
+        /// <param name="assembly">assembly containing types that declare the NmeaMessageTypeAttribute</param>
+	    public static void RegisterNmeaMessages(Assembly assembly)
+	    {
+            foreach (var subclass in assembly.DefinedTypes.Where(t => t.IsSubclassOf(typeof(NmeaMessage))))
+            {
+                RegisterNmeaMessage(subclass);
+            }
+	    }
 
         /// <summary>
         /// Registers the specified type as a parse 'target'. The type needs to declare the NmeaMessageTypeAttribute.

--- a/src/NmeaParser.Shared/Nmea/NmeaMessage.cs
+++ b/src/NmeaParser.Shared/Nmea/NmeaMessage.cs
@@ -111,26 +111,45 @@ namespace NmeaParser.Nmea
 			var typeinfo = typeof(NmeaMessage).GetTypeInfo();
 			foreach (var subclass in typeinfo.Assembly.DefinedTypes.Where(t => t.IsSubclassOf(typeof(NmeaMessage))))
 			{
-				var attr = subclass.GetCustomAttribute<NmeaMessageTypeAttribute>(false);
-				if (attr != null)
-				{
-					if (!subclass.IsAbstract)
-					{
-						foreach (var c in subclass.DeclaredConstructors)
-						{
-							var pinfo = c.GetParameters();
-							if (pinfo.Length == 0)
-							{
-								messageTypes.Add(attr.NmeaType, c);
-								break;
-							}
-						}
-					}
-				}
+			    RegisterNmeaMessage(subclass);
 			}
 		}
 
-		private static Dictionary<string, ConstructorInfo> messageTypes;
+        /// <summary>
+        /// Registers the specified type as a parse 'target'. The type needs to declare the NmeaMessageTypeAttribute.
+        /// </summary>
+        /// <param name="typeInfo">typeInfo of the type to register</param>
+        /// <example>
+        /// <code>
+        /// NmeaMessage.RegisterNmeaMessage(typeof(Oprpm).GetTypeInfo());
+        /// </code>
+        /// </example>
+	    public static void RegisterNmeaMessage(TypeInfo typeInfo)
+	    {
+            if (messageTypes == null)
+            {
+                LoadResponseTypes();
+            }
+
+	        var attr = typeInfo.GetCustomAttribute<NmeaMessageTypeAttribute>(false);
+	        if (attr != null)
+	        {
+	            if (!typeInfo.IsAbstract)
+	            {
+	                foreach (var c in typeInfo.DeclaredConstructors)
+	                {
+	                    var pinfo = c.GetParameters();
+	                    if (pinfo.Length == 0)
+	                    {
+	                        messageTypes.Add(attr.NmeaType, c);
+	                        break;
+	                    }
+	                }
+	            }
+	        }
+	    }
+
+	    private static Dictionary<string, ConstructorInfo> messageTypes;
 
 		/// <summary>
 		/// Gets the NMEA message parts.


### PR DESCRIPTION
While using the library through NuGet and in a Windows Application, I was not able to add my own NmeaMessages, since only the assembly where the NmeaMessage is defined is being searched. You cannot simply change that behavior to searching through all assemblies in the AppDomain, since the AppDomain is not available in WinStore and WinPhone apps. 

This commit adds the option to register types at will.
