### PR TITLE
Updated code that parses geodetic values

### DIFF
--- a/src/NmeaParser/Nmea/NmeaMessage.cs
+++ b/src/NmeaParser/Nmea/NmeaMessage.cs
@@ -188,8 +188,10 @@ namespace NmeaParser.Nmea
 		{
 			if (value == null || value.Length < 3)
 				return double.NaN;
-			double latitude = int.Parse(value.Substring(0, 2), CultureInfo.InvariantCulture) + double.Parse(value.Substring(2), CultureInfo.InvariantCulture) / 60;
-			if (ns == "S")
+            int decimalIndex = value.IndexOf(".");
+            int wholeLength = decimalIndex - 2;
+            double latitude = int.Parse(value.Substring(0, wholeLength), CultureInfo.InvariantCulture) + double.Parse(value.Substring(wholeLength), CultureInfo.InvariantCulture) / 60;
+            if (ns == "S")
 				latitude *= -1;
 			return latitude;
 		}
@@ -198,8 +200,10 @@ namespace NmeaParser.Nmea
 		{
 			if (value == null || value.Length < 4)
 				return double.NaN;
-			double longitude = int.Parse(value.Substring(0, 3), CultureInfo.InvariantCulture) + double.Parse(value.Substring(3), CultureInfo.InvariantCulture) / 60;
-			if (ew == "W")
+            int decimalIndex = value.IndexOf(".");
+            int wholeLength = decimalIndex - 2;
+            double longitude = int.Parse(value.Substring(0, wholeLength), CultureInfo.InvariantCulture) + double.Parse(value.Substring(wholeLength), CultureInfo.InvariantCulture) / 60;
+            if (ew == "W")
 				longitude *= -1;
 			return longitude;
 		}


### PR DESCRIPTION
Some devices emitting NMEA 0183 sentences did not always send two digits for latitude degrees or three digits for longitude degrees.  Parser was changed to look for the position of the decimal point to derive the location of the other sub-fields. 