### PR TITLE
Fix baud rate for IProgress in FindPort

### DIFF
--- a/src/SampleApp.WinDesktop/MainWindow.xaml.cs
+++ b/src/SampleApp.WinDesktop/MainWindow.xaml.cs
@@ -184,7 +184,7 @@ namespace SampleApp.WinDesktop
                     {
 
                         if (progress != null)
-                            progress.Report(string.Format("Trying {0} @ {1}baud", portName, port.BaudRate));
+                            progress.Report(string.Format("Trying {0} @ {1}baud", portName, baud));
                         port.BaudRate = baud;
                         port.ReadTimeout = 2000; //this might not be long enough
                         bool success = false;


### PR DESCRIPTION
IProgress was showing `port.BaudRate` instead of `baud` the baud rate currently being tested.