### PR TITLE
Fix RMC FixTime parsing that can lose sub-second precision with doubles

### DIFF
--- a/src/NmeaParser/Nmea/Rmc.cs
+++ b/src/NmeaParser/Nmea/Rmc.cs
@@ -42,12 +42,15 @@ namespace NmeaParser.Messages
             
             if (message[8].Length == 6 && message[0].Length >= 6)
             {
-                FixTime = new DateTimeOffset(int.Parse(message[8].Substring(4, 2), CultureInfo.InvariantCulture) + 2000,
-                                       int.Parse(message[8].Substring(2, 2), CultureInfo.InvariantCulture),
-                                       int.Parse(message[8].Substring(0, 2), CultureInfo.InvariantCulture),
-                                       int.Parse(message[0].Substring(0, 2), CultureInfo.InvariantCulture),
-                                       int.Parse(message[0].Substring(2, 2), CultureInfo.InvariantCulture),
-                                       0, TimeSpan.Zero).AddSeconds(double.Parse(message[0].Substring(4), CultureInfo.InvariantCulture));
+                var year = int.Parse(message[8].Substring(4, 2), CultureInfo.InvariantCulture) + 2000;
+                var month = int.Parse(message[8].Substring(2, 2), CultureInfo.InvariantCulture);
+                var day = int.Parse(message[8].Substring(0, 2), CultureInfo.InvariantCulture);
+                var hour = int.Parse(message[0].Substring(0, 2), CultureInfo.InvariantCulture);
+                var minute = int.Parse(message[0].Substring(2, 2), CultureInfo.InvariantCulture);
+                var seconds = double.Parse(message[0].Substring(4), CultureInfo.InvariantCulture);
+
+                FixTime = new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero)
+                    .AddSeconds(seconds);
             }
             Active = (message[1] == "A");
             Latitude = NmeaMessage.StringToLatitude(message[2], message[3]);

--- a/src/NmeaParser/Nmea/Rmc.cs
+++ b/src/NmeaParser/Nmea/Rmc.cs
@@ -47,10 +47,10 @@ namespace NmeaParser.Messages
                 var day = int.Parse(message[8].Substring(0, 2), CultureInfo.InvariantCulture);
                 var hour = int.Parse(message[0].Substring(0, 2), CultureInfo.InvariantCulture);
                 var minute = int.Parse(message[0].Substring(2, 2), CultureInfo.InvariantCulture);
-                var seconds = double.Parse(message[0].Substring(4), CultureInfo.InvariantCulture);
+                var secondTicks = (long)(decimal.Parse(message[0].Substring(4), CultureInfo.InvariantCulture) * TimeSpan.TicksPerSecond);
 
                 FixTime = new DateTimeOffset(year, month, day, hour, minute, 0, TimeSpan.Zero)
-                    .AddSeconds(seconds);
+                    .AddTicks(secondTicks);
             }
             Active = (message[1] == "A");
             Latitude = NmeaMessage.StringToLatitude(message[2], message[3]);


### PR DESCRIPTION
When calling `AddSeconds` on the `DateTimeOffset`, in .NET 6 it rounds the double to the closest millisecond value. However, this changed in .NET 7. https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/datetime-add-precision

Regardless of whether or not this package adds .NET 7 support, this change will ensure that we don't lose any subsecond precision from the NMEA message. 

For NMEA messages that have less than 3 digits of precision, this will not change any behavior
`"$GPRMC,141825.2,A,4249.92297,N,08548.52186,W,000.01,227.1,040322,005.5,W*54"`

But for NMEA messages with more than 3 digits of precision, this will preserve that precision.
`"$GPRMC,141825.1999,A,4249.92297,N,08548.52186,W,000.01,227.1,040322,005.5,W*54"`